### PR TITLE
update repo url of micro-vcs plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This repository contains the 'channel.json' file which lists all official micro 
 | `monokai-dark`  | A dark monokai colorscheme                              | https://github.com/Theodus/micro-monokai-dark              | :heavy_check_mark: (provided by default) |
 | `manipulator`   | Extend text manipulation abilities                      | https://github.com/NicolaiSoeborg/manipulator-plugin       | :heavy_check_mark:                       |
 | `filemanager`   | A file manager!                                         | https://github.com/NicolaiSoeborg/filemanager-plugin       | :heavy_check_mark:                       |
-| `vcs`           | Mark changed lines in Git or Mercurial repositories     | https://bitbucket.org/dermetfan/micro-vcs                  | :heavy_check_mark: (provided by default) |
+| `vcs`           | Mark changed lines in Git or Mercurial repositories     | https://hg.sr.ht/~dermetfan/micro-vcs                      | :heavy_check_mark: (provided by default) |
 | `joinLines`     | Plugin which joins selected lines or the following with the current | https://github.com/Lisiadito/join-lines-plugin | :heavy_check_mark:                       |
 | `bounce`     | Plugin that implements nano-style smart home and bouncing the cursor between matching-brackets | https://github.com/deusnefum/micro-bounce | :heavy_check_mark:                       |
 | `quoter`     | Plugin that allows you to add quotes or brackets around selected text | https://github.com/deusnefum/micro-quoter | :heavy_check_mark:                       |


### PR DESCRIPTION
Simple update of the readme file, as it seems to have moved from bitbucket to sr.ht


